### PR TITLE
fix page.url variable

### DIFF
--- a/lib/parsers/page.js
+++ b/lib/parsers/page.js
@@ -34,7 +34,7 @@ function Page(attrs) {
     }
   }
 
-  this.url = '/' + (this.path.indexOf(path.sep) >= 0 ? path.dirname(this.path) : '')
+  this.url = path.resolve('/', this.path)
 
   this.dest = path.join(this.site.dest, this.site.baseurl.slice(1),
     this.path.replace(/\.\w+$/, this.ext == '.md' ? '.html' : this.ext))


### PR DESCRIPTION
according to jekyll docs (http://jekyllrb.com/docs/variables/)
page.url should return "The URL of the Post without the domain, but with a leading slash, e.g. /2008/12/14/my-post.html"

Current code for files directly in src directory returns URL -> / (without filename)
For others subdirectories /path_to_dir (without filename)

URL should contain filename too